### PR TITLE
Fail on missing @sample

### DIFF
--- a/jsdoc/plugins/highcharts.jsdoc.js
+++ b/jsdoc/plugins/highcharts.jsdoc.js
@@ -1006,7 +1006,7 @@ exports.defineTags = function (dictionary) {
             doclet.samples = doclet.samples || [];
 
             if (!fs.existsSync(folder)) {
-                console.error('@sample does not exist: ' + value);
+                logger.error('@sample does not exist: ' + value);
             }
             doclet.samples.push({
                 name: name,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@highcharts/highcharts-documentation-generators",
-    "version": "0.6.2",
+    "version": "0.6.3",
     "author": "Highsoft AS",
     "license": "UNLICENSED",
     "bugs": {


### PR DESCRIPTION
The error `@sample does not exist` now causes failure in CI, not just a warning. Otherwise it passes unnoticed.